### PR TITLE
Improve config flexibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ Provide the SSH key for access to Dokku in the `SSH_PRIVATE_KEY` secret.
 
 `Procfile` contains the command for running the main process of the application.
 
+## Environment variables
+
+| Variable     | Default | Meaning                                            |
+|--------------|---------|----------------------------------------------------|
+| RUN_ATTEMPTS | 4       | Number of attempts to run a specific workflow job. |
+
 ## Updating GitHub token
 
 To update the token or change the user which will restart workflows:

--- a/README.md
+++ b/README.md
@@ -39,9 +39,10 @@ Provide the SSH key for access to Dokku in the `SSH_PRIVATE_KEY` secret.
 
 ## Environment variables
 
-| Variable     | Default | Meaning                                            |
-|--------------|---------|----------------------------------------------------|
-| RUN_ATTEMPTS | 4       | Number of attempts to run a specific workflow job. |
+| Variable      | Default | Meaning                                                   |
+|---------------|---------|-----------------------------------------------------------|
+| RUN_ATTEMPTS  | 4       | Number of attempts to run a specific workflow job.        |
+| REPO_BRANCHES | master  | Branches that require automatic restart of workflow jobs. |
 
 ## Updating GitHub token
 

--- a/init.lua
+++ b/init.lua
@@ -3,7 +3,7 @@ local client = require('http.client').new()
 local json = require('json')
 local fiber = require('fiber')
 local log = require('log')
-local max_attempts = 4
+local run_attempts = os.getenv("RUN_ATTEMPTS") or 4
 local no_retry_list = os.getenv("NO_RETRY_LIST")
 
 box.cfg({
@@ -68,8 +68,8 @@ function webhook_handler(req)
         log.error('Empty payload')
         return { status = 204 }
     end
-    if payload.workflow_job.run_attempt >= max_attempts then
-        log.info('Attempt >= '..max_attempts..', no action needed')
+    if payload.workflow_job.run_attempt >= run_attempts then
+        log.info('Attempt >= '..run_attempts..', no action needed')
         return { status = 204 }
     end
     local workflow_run_id = payload.workflow_job.run_id


### PR DESCRIPTION
### Description

Improved service configuration by using environment variables.

### What's new in the administration

List of environment variables has been extended:

`RUN_ATTEMPTS` - number of attempts to run a specific GitHub Action Job; The default values is 4.
```bash
export RUN_ATTEMPTS=2
```

`REPO_BRANCHES` - Branches that require automatic restart of GitHub Action Jobs. The default value is 'master'.
```bash
export REPO_BRANCHES=master,my-branch,custom,1.2
```

Closes #15 
Closes #21